### PR TITLE
adds a vscode task to flash the codebase to a micropython device

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Upload to RP2040",
+      "type": "shell",
+      "command": "rshell",
+      "args": ["rsync", "-m", ".", "/pyboard/"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Upload to RP2040",
+      "label": "Upload to µC",
       "type": "shell",
       "command": "rshell",
       "args": ["rsync", "-m", ".", "/pyboard/"],


### PR DESCRIPTION
This VS Code task will push the code base to a micropython device connected to the host.

It uses `rshell` to find a device and sync the python code on the µC to what is in the local repo. It is not currently setup to target any specific device, so if you have multiple micropython devices connected, the device it will target is undefined.

To run this task, just execute the "Run Build Task" command in VS Code.